### PR TITLE
✨  동아리 정보를 반환하는 api와 모집 공고를 찜하는 api 구현하기

### DIFF
--- a/post/serializers.py
+++ b/post/serializers.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+from django.contrib.auth import get_user_model
+from table.models import *
+from django.core.exceptions import ObjectDoesNotExist
+

--- a/post/urls.py
+++ b/post/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, include
 from .views import *
 
 urlpatterns = [
-    path('get-crew-info/', get_crew_info, name='get-crew-info'), # 1번
+    path('get-crew-info/', get_crew_info, name='get-crew-info'),  # 1번
+    path('like-post/', like_post, name='like-post'),              # 2번
 ]
     

--- a/post/urls.py
+++ b/post/urls.py
@@ -2,6 +2,6 @@ from django.urls import path, include
 from .views import *
 
 urlpatterns = [
-    
+    path('get-crew-info/', get_crew_info, name='get-crew-info'), # 1번
 ]
     

--- a/post/views.py
+++ b/post/views.py
@@ -14,11 +14,13 @@ from django.core.exceptions import ObjectDoesNotExist
 def get_crew_info(request):
     # post-man 테스트 완료
     
-    post_title = request.GET.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 전달 받음 (url 쿼리 파라미터로 넘김)
-    crew_name = request.GET.get('crew_name')  # 클라이언트로부터 crew의 이름 가져옴
+    # post_title = request.GET.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 전달 받음 (url 쿼리 파라미터로 넘김)
+    # crew_name = request.GET.get('crew_name')  # 클라이언트로부터 crew의 이름 가져옴
+
+    post_id = request.GET.get('id')
 
     try:
-        post = Post.objects.get(title = post_title, crew__crew_name = crew_name)
+        post = Post.objects.get(id=post_id)
     except Post.DoesNotExist:
         return Response({"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND)
     
@@ -41,14 +43,16 @@ def get_crew_info(request):
 def like_post(request):
 
     user = request.user
-    post_title = request.data.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 받음
-    crew_name = request.data.get('crew_name')  # 클라이언트로부터 crew의 이름 받음
+    # post_title = request.data.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 받음
+    # crew_name = request.data.get('crew_name')  # 클라이언트로부터 crew의 이름 받음
+
+    post_id = request.GET.get('id')
 
     if(user.is_operator == True):  
-        return Response({"error": "He is Administrator, not general User!"}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+        return Response({"error": "He is Administrator, not general User!"}, status=status.HTTP_403_FORBIDDEN)
     
     try:
-        post = Post.objects.get(title = post_title, crew__crew_name = crew_name)
+        post = Post.objects.get(id = post_id)
     except Post.DoesNotExist:
         return Response({"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND)
     

--- a/post/views.py
+++ b/post/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+from table.models import *
+from .serializers import *
 
-# Create your views here.
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from django.core.exceptions import ObjectDoesNotExist
+
+# 1. 동아리 정보 반환하는 api (GET), 이건 기본 정보 반환이라 로그인 유무 상관 없음.
+# 동아리 이름, 동아리 한줄 소개, 동아리 프로필 사진, 동아리 카테고리 등의 정보 반환
+@api_view(['GET'])
+@permission_classes([permissions.AllowAny])
+def get_crew_info(request):
+    
+    post_title = request.GET.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 전달 받음 (url 쿼리 파라미터로 넘김)
+
+    try:
+        post = Post.objects.get(title = post_title)
+    except Post.DoesNotExist:
+        return Response({"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND)
+    
+    crew = post.crew  # 해당 Post 객체에 연결되어있는 Crew 객체 반환
+
+    context = {
+        "crew_name" : crew.crew_name,
+        "post_title" : post.title,
+        "crew_description" : crew.description,
+        # "crew_photo" : crew.photo, 
+        "category" : crew.category.category_name if crew.category else None, # 카테고리가 없으면 None으로 보내도록 분기 처리
+    }
+
+    return Response(context, status=status.HTTP_200_OK)
+
+
+

--- a/post/views.py
+++ b/post/views.py
@@ -12,11 +12,13 @@ from django.core.exceptions import ObjectDoesNotExist
 @api_view(['GET'])
 @permission_classes([permissions.AllowAny])
 def get_crew_info(request):
+    # 테스트 완료
     
     post_title = request.GET.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 전달 받음 (url 쿼리 파라미터로 넘김)
+    crew_name = request.GET.get('crew_name')  # 클라이언트로부터 crew의 이름 가져옴
 
     try:
-        post = Post.objects.get(title = post_title)
+        post = Post.objects.get(title = post_title, crew__crew_name = crew_name)
     except Post.DoesNotExist:
         return Response({"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND)
     
@@ -31,6 +33,9 @@ def get_crew_info(request):
     }
 
     return Response(context, status=status.HTTP_200_OK)
+
+
+
 
 
 

--- a/post/views.py
+++ b/post/views.py
@@ -7,6 +7,9 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from django.core.exceptions import ObjectDoesNotExist
 
+from django.utils import timezone  # now = timezone.now() 이렇게 사용하기
+
+
 # 1. 동아리 정보 반환하는 api (GET), 이건 기본 정보 반환이라 로그인 유무 상관 없음.
 # 동아리 이름, 동아리 한줄 소개, 동아리 프로필 사진, 동아리 카테고리 등의 정보 반환
 @api_view(['GET'])
@@ -36,7 +39,6 @@ def get_crew_info(request):
 
     return Response(context, status=status.HTTP_200_OK)
 
-
 # 2. 유저가 해당 Post 찜 등록 or 해제 하기
 @api_view(['POST'])
 @permission_classes([permissions.IsAuthenticated])
@@ -46,7 +48,7 @@ def like_post(request):
     # post_title = request.data.get('post_title')  # 클라이언트로부터 공고(Post)의 title을 받음
     # crew_name = request.data.get('crew_name')  # 클라이언트로부터 crew의 이름 받음
 
-    post_id = request.GET.get('id')
+    post_id = request.data.get('id')
 
     if(user.is_operator == True):  
         return Response({"error": "He is Administrator, not general User!"}, status=status.HTTP_403_FORBIDDEN)
@@ -65,12 +67,18 @@ def like_post(request):
             post = post
         )
         new_like.save()
-        
+
         return Response({"message": "Like has been added."}, status=status.HTTP_201_CREATED)
 
     # 해당 like 객체를 삭제해야.
     like.delete()
     return Response({"message": "Like has been removed."}, status=status.HTTP_200_OK)
+
+
+
+
+    
+
 
 
 


### PR DESCRIPTION
## Check 🌈

- [x] merge할 브랜치가 dev인가요? (main ❌)
- [x] 리뷰가 필요한 경우 review 라벨을 달고 리뷰어를 지정해주세요
- [x] 승인된 PR의 merge는 PR 작성자가 합니다
- [x] PR의 라벨을 제대로 달았나요?

## Description 📒

post 앱에서 가장 기본적인 GET 요청을 담당하는 get_crew_info 뷰를 만들었습니다.
상세페이지에 접속했을 때 해당 공고의 주체인 동아리의 이름과 한줄 소개, 동아리 사진, 카테고리등의 정보를 반환하는 api입니다.

또한 2번 api인 like_post도 구현하였습니다. 이는 로그인한 유저가 특정 post를 찜하는 로직입니다.
만약 기존에 찜이 되어 있었다면 기존의 찜을 삭제하고, 기존에 찜이 되어있지 않았다면 새로운 LIke 릴레이션의 튜플을 생성하는 api입니다.

## Issue Number 💬

샵 뒤에 이슈 번호를 쓰면 등록됩니다

## To Reviewer 💌
1번 - Response 하는 과정에서 Crew모델과 Post 모델 등 두 모델 모두를 처리해야했기 떄문에 Serializer 를 굳이 사용하지 않고
인위적으로 Json 파일 형식과 사실상 동일한 딕셔너리 변수를 만들어 그 안에 정보를 담아 이를 Response 하였습니다.

2번 - 찜하는 기능을 가진 api는 Like 객체의 생성과 소멸 관련 메시지만 반환하면 되기 때문에 이 역시 굳이 Serializer를 만들지 않았습니다.

