### PR TITLE
✨ 유저가 클릭한 Post의 정보들을 반환하는 Api 구현하기, 유저가 클릭한 Post 상세 페이지에서 지원 관련 버튼 정보 GET Api

### DIFF
--- a/post/serializers.py
+++ b/post/serializers.py
@@ -3,3 +3,30 @@ from django.contrib.auth import get_user_model
 from table.models import *
 from django.core.exceptions import ObjectDoesNotExist
 
+class PostContent_PostImageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PostImage
+        fields = "__all__"
+
+class PostContent_PostSerializer(serializers.ModelSerializer):
+    image = PostContent_PostImageSerializer(many=True, read_only = True)     # Post 모델의 related_name과 동일하게 설정
+
+    class Meta:
+        model = Post
+        fields = ['id', 'apply_start_date', 'apply_end_date', 'document_result_date', 'has_interview', 'interview_start_date', 
+                'interview_end_date', 'final_result_date', 'requirement_target', 'title', 'content', 'membership_fee', 'created_at',
+                'image' ]
+
+        
+
+
+
+
+
+
+
+
+
+
+
+

--- a/post/urls.py
+++ b/post/urls.py
@@ -2,8 +2,9 @@ from django.urls import path, include
 from .views import *
 
 urlpatterns = [
-    path('get-crew-info/', get_crew_info, name='get-crew-info'),  # 1번
-    path('like-post/', like_post, name='like-post'),              # 2번
-    path('post-content/', post_content, name='post-content'),     # 3번
+    path('get-crew-info/', get_crew_info, name='get-crew-info'),                 # 1번
+    path('like-post/', like_post, name='like-post'),                             # 2번
+    path('post-content/', post_content, name='post-content'),                    # 3번
+    path('click-apply-button/', click_apply_button, name='click-apply-button'),  # 4번
 ]
     

--- a/post/urls.py
+++ b/post/urls.py
@@ -4,5 +4,6 @@ from .views import *
 urlpatterns = [
     path('get-crew-info/', get_crew_info, name='get-crew-info'),  # 1번
     path('like-post/', like_post, name='like-post'),              # 2번
+    path('post-content/', post_content, name='post-content'),     # 3번
 ]
     

--- a/post/views.py
+++ b/post/views.py
@@ -12,6 +12,7 @@ from django.utils import timezone  # now = timezone.now() 이렇게 사용하기
 
 # 1. 동아리 정보 반환하는 api (GET), 이건 기본 정보 반환이라 로그인 유무 상관 없음.
 # 동아리 이름, 동아리 한줄 소개, 동아리 프로필 사진, 동아리 카테고리 등의 정보 반환
+# + 추가 -> 동아리 리쿠르팅 일정 정보도 같이 반환해서 주기
 @api_view(['GET'])
 @permission_classes([permissions.AllowAny])
 def get_crew_info(request):
@@ -75,7 +76,26 @@ def like_post(request):
     return Response({"message": "Like has been removed."}, status=status.HTTP_200_OK)
 
 
+# 3번 해당 Post의 기본 정보 반환하기
+@api_view(['GET'])
+@permission_classes([permissions.AllowAny])
+def post_content(request):
+    # post-man 테스트 완료
 
+    post_id = request.GET.get('id')  # GET이니 쿼리 파라미터로 받기
+
+    try:
+        post = Post.objects.get(id = post_id)
+    except Post.DoesNotExist:
+        return Response({"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND)
+    
+    serializer = PostContent_PostSerializer(post)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+
+
+    
 
     
 


### PR DESCRIPTION
## Check 🌈

- [x] merge할 브랜치가 dev인가요? (main ❌)
- [x] 리뷰가 필요한 경우 review 라벨을 달고 리뷰어를 지정해주세요
- [x] 승인된 PR의 merge는 PR 작성자가 합니다
- [x] PR의 라벨을 제대로 달았나요?

## Description 📒

3번 - 유저가 자신이 원하는 Post의 상세 페이지를 클릭했을 때, 해당 post 관련 내용들과 Post 와 1 대 다 관계로 연결되어있는 PostImage 객체들의 정보를 리스트에 담아 json 파일 형식으로 함께 전달해주는 3번 api를 만들었습니다.

4번 - 어떤 유저가 특정 Post의 상세 페이지를 클릭했을 때, 지원서 관련 버튼을 유저 상태에 따라 다른 정보를 반환할 수 있도록 하는 api를 만들었습니다. 예를 들어 그 User가 로그인을 하지 않고 그냥 눈팅하는 유저인지, 로그인을 한 유저이면서 동시에 그 Post를 올린 동아리의 운영진 계정인지, 로그인을 한 유저이고 운영진 계정이지만 해당 Post를 개설한 동아리의 운영진은 아닌 경우인지, 로그인을 한 유저이지만 운영진 계정이 아닌 그냥 일반 유저인 경우인데 해당 Post에 이미 apply 한 유저인지, 로그인을 한 유저이지만 역시 운영진 계정이 아니고 일반 유저인데 해당 Post에 apply도 하지 않은 유저인지 등을 고려하면서 동시에 해당 Post를 올릴 때 등록한 각 절차별 시간과 유저가 해당 상세 페이지에 들어온 시간과의 관계를 고려하여 클라이언트가 어떤 버튼을 만들어야 하는지 그 정보를 반환해주는 api입니다.

## Issue Number 💬

샵 뒤에 이슈 번호를 쓰면 등록됩니다

## To Reviewer 💌

3번 - 해당 view를 만들 때 1 대 다로 연결되어있는 두 모델을 한 json에 담아 Response 하기 위해 serializer를 구현할 때
PostImage 모델을 직렬화 하는 Serializer를 먼저 만들고 이를 Post 모델을 직렬화 할 때 사용하는 serializer안에 nested 될 수 있도록
두 개를 만들었습니다. 

4번 - 그냥 코드에 나와있는 주석 참고하시면 코드 다 이해 될 겁니다.