### PR TITLE
✨ 모집 공고와 지원서 양식을 생성하는 기능 구현하기

### DIFF
--- a/apply/permissions.py
+++ b/apply/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework import permissions
+
+# 동아리 운영진에 대한 permission
+class IsAdministrator(permissions.BasePermission):
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_operator)

--- a/apply/permissions.py
+++ b/apply/permissions.py
@@ -1,7 +1,10 @@
 from rest_framework import permissions
+from rest_framework.exceptions import PermissionDenied
 
 # 동아리 운영진에 대한 permission
 class IsAdministrator(permissions.BasePermission):
 
     def has_permission(self, request, view):
-        return bool(request.user and request.user.is_operator)
+        if request.user and request.user.is_operator:
+            return True
+        raise PermissionDenied(detail="Request user is not crew administrator")

--- a/apply/serializers.py
+++ b/apply/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from table.models import Post
+
+class PostSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Post
+        exclude = ['pass_message', 'fail_message', 'created_at']

--- a/apply/serializers.py
+++ b/apply/serializers.py
@@ -1,7 +1,32 @@
 from rest_framework import serializers
-from table.models import Post
+from table.models import Post, Section, LongSentence, CheckBox, File, CheckBoxOption
 
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         exclude = ['pass_message', 'fail_message', 'created_at']
+
+class SectionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Section
+        fields = '__all__'
+
+class LongSentenceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LongSentence
+        fields = '__all__'
+
+class CheckBoxSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CheckBox
+        fields = '__all__'
+
+class FileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = File
+        fields = '__all__'
+
+class CheckBoxOptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CheckBoxOption
+        fields = '__all__'

--- a/apply/tests.py
+++ b/apply/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/apply/tests/application_create_test.py
+++ b/apply/tests/application_create_test.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+from django.shortcuts import get_object_or_404, get_list_or_404
+from rest_framework.test import APIClient
+from table.models import Crew, Post, Section, LongSentence, CheckBox, CheckBoxOption, File
+from .test_constants import LONG_SENTENCE_CREATE_REQUEST, CHECKBOX_FILE_CREATE_REQUEST
+
+
+# 지원서를 생성한다
+class ApplicationCreateTest(TestCase):
+    url = '/apply/1/application/'
+
+    def setUp(self):
+        self.crew = Crew.objects.create(id=1, crew_name="0", description="0")
+        self.post = Post.objects.create(id=1,
+                            apply_start_date="1000-01-01 00:00:00",
+                            apply_end_date="1000-01-01 00:00:00",
+                            document_result_date="1000-01-01 00:00:00",
+                            has_interview=False,
+                            requirement_target="0",
+                            title="0",
+                            content="0",
+                            membership_fee="0",
+                            crew=self.crew,
+                            progress="0")
+
+    # 공통 섹션과 장문형 문항을 생성한다.
+    def long_sentence_question_test(self):
+        # given & when
+        client = APIClient()
+        response = client.post(self.url,
+                               data=LONG_SENTENCE_CREATE_REQUEST,
+                               format='json')
+
+        # then
+        saved_section = get_object_or_404(Section, section_name=LONG_SENTENCE_CREATE_REQUEST["section_name"])
+        saved_long_sentence1 = get_object_or_404(LongSentence, question=LONG_SENTENCE_CREATE_REQUEST["question"][0]["question"])
+        saved_long_sentence2 = get_object_or_404(LongSentence, question=LONG_SENTENCE_CREATE_REQUEST["question"][1]["question"])
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(saved_section.post, self.post)
+        self.assertEqual(saved_section.description, LONG_SENTENCE_CREATE_REQUEST["description"])
+        self.assertEqual(saved_long_sentence1.section, saved_section)
+        self.assertEqual(saved_long_sentence2.letter_count_limit, LONG_SENTENCE_CREATE_REQUEST["question"][1]["letter_count_limit"])
+
+    # 객관식 문항(checkbox)과 파일 문항을 생성한다.
+    def checkbox_file_question_test(self):
+        # given & when
+        client = APIClient()
+        response = client.post(self.url,
+                               data=CHECKBOX_FILE_CREATE_REQUEST,
+                               format='json')
+        
+        # then
+        saved_checkbox = get_object_or_404(CheckBox, question=CHECKBOX_FILE_CREATE_REQUEST["question"][0]["question"])
+        saved_options = get_list_or_404(CheckBoxOption, check_box=saved_checkbox)
+        saved_file_question = get_object_or_404(File, question=CHECKBOX_FILE_CREATE_REQUEST["question"][1]["question"])
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(saved_checkbox.answer_minumum, CHECKBOX_FILE_CREATE_REQUEST["question"][0]["answer_minumum"])
+        self.assertEqual(saved_options[0].option, CHECKBOX_FILE_CREATE_REQUEST["question"][0]["options"][0])
+        self.assertEqual(saved_file_question.is_essential, CHECKBOX_FILE_CREATE_REQUEST["question"][1]["is_essential"])

--- a/apply/tests/post_test.py
+++ b/apply/tests/post_test.py
@@ -1,0 +1,72 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, APIClient
+from django.shortcuts import get_object_or_404
+from table.models import Crew, Post
+from ..permissions import IsAdministrator
+from .test_constants import POST_REQUEST, BAD_POST_REQUEST
+
+from django.contrib.auth import get_user_model
+User = get_user_model()
+
+
+# 모집 공고를 생성한다
+class PostCreateTest(TestCase):
+    url = '/apply/'
+
+    def setUp(self):
+        self.crew = Crew.objects.create(id=1, crew_name="멋쟁이사자처럼",
+                                        description="전국 연합 IT 동아리, 멋쟁이사자처럼입니다!")
+        self.user = User.objects.create_user(
+            email="test@naver.com", name="test user", password="1234")
+        self.user.is_operator = True
+
+
+    # 모집 공고를 생성하여 STATUS 201을 반환한다
+    def test_post_create(self):
+        # given
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        # when
+        response = client.post(self.url,
+                               data=POST_REQUEST,
+                               format='json')
+
+        # then
+        saved_post = get_object_or_404(Post, title=POST_REQUEST['title'])
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(saved_post.title, POST_REQUEST['title'])
+        self.assertEqual(saved_post.crew.id, POST_REQUEST['crew'])
+
+
+    # 잘못된 모집 공고 생성 요청으로 STATUS 400을 반환한다
+    def test_no_interview_post_create(self):
+        # given
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        # when
+        response = client.post(self.url,
+                               data=BAD_POST_REQUEST,
+                               format='json')
+
+        # then
+        self.assertEqual(response.status_code, 400)
+        print(response.json())
+        
+
+    # 동아리 운영진 권한을 갖는다
+    def test_create_permission(self):
+        # given
+        factory = APIRequestFactory()
+        request = factory.post(self.url,
+                               data=POST_REQUEST,
+                               format='json')
+        request.user = self.user
+
+        # when
+        permission = IsAdministrator()
+        has_permission = permission.has_permission(request, None)
+
+        # then
+        self.assertTrue(has_permission)

--- a/apply/tests/test_constants.py
+++ b/apply/tests/test_constants.py
@@ -1,0 +1,37 @@
+"""
+테스트를 위한 CONSTANT
+"""
+
+
+'''
+모집 공고 생성 요청
+'''
+POST_REQUEST = {"apply_start_date": "2023-09-20 00:00:00",
+                "apply_end_date": "2023-09-22 00:00:00",
+                "document_result_date": "2023-09-23 00:00:00",
+                "has_interview": "true",
+                "interview_start_date": "2023-10-01 00:00:00",
+                "interview_end_date": "2023-10-02 00:00:00",
+                "final_result_date": "2023-10-03 00:00:00",
+                "requirement_target": "열정 있는 미래 창업인들",
+                "title": "서강대학교 멋쟁이사자처럼 12기에서 신입 부원을 모집합니다!",
+                "content": "OT 필참이며 날짜는 23년 10월 10일입니다!",
+                "membership_fee": "1년 활동 기간 동안 동아리에서 사용할 6만원",
+                "crew": 1,
+                "progress": "1차는 서류, 2차는 비대면(Zoom) 면접"}
+
+
+'''
+잘못된 모집 공고 생성 요청
+- content가 없어서 validation 문제가 발생한다
+- 1차 전형만 있어서 면접 일정이 입력되지 않는다
+'''
+BAD_POST_REQUEST = {"apply_start_date": "2023-09-20 00:00:00",
+                    "apply_end_date": "2023-09-22 00:00:00",
+                    "document_result_date": "2023-09-23 00:00:00",
+                    "has_interview": "false",
+                    "requirement_target": "열정 있는 미래 창업인들",
+                    "title": "서강대학교 멋쟁이사자처럼 12기에서 신입 부원을 모집합니다!",
+                    "membership_fee": "1년 활동 기간 동안 동아리에서 사용할 6만원",
+                    "crew": 1,
+                    "progress": "1차 서류만 진행합니다."}

--- a/apply/tests/test_constants.py
+++ b/apply/tests/test_constants.py
@@ -35,3 +35,51 @@ BAD_POST_REQUEST = {"apply_start_date": "2023-09-20 00:00:00",
                     "membership_fee": "1년 활동 기간 동안 동아리에서 사용할 6만원",
                     "crew": 1,
                     "progress": "1차 서류만 진행합니다."}
+
+
+'''
+지원서 중 장문형 문항 생성 요청
+'''
+LONG_SENTENCE_CREATE_REQUEST = {
+    "section_name": "공통",
+    "description": "모든 사람이 답변해야 하는 공통 문항입니다.",
+    "question":
+    [
+        {
+            "type": "long_sentence",
+            "is_essential": True,
+            "question": "자기소개하세요.",
+            "letter_count_limit": 300
+        },
+        {
+            "type": "long_sentence",
+            "is_essential": True,
+            "question": "지원 동기를 적어주세요.",
+            "letter_count_limit": 500
+        }
+    ]
+}
+
+'''
+지원서 중 객관식 & 파일 문항 생성 요청
+'''
+CHECKBOX_FILE_CREATE_REQUEST = {
+    "section_name": "공통",
+    "description": "모든 사람이 답변해야 하는 공통 문항입니다.",
+    "question":
+    [
+        {
+            "type": "checkbox",
+            "is_essential": True,
+            "question": "옵션 중 하나를 선택하세요.",
+            "answer_minumum": 1,
+            "answer_maximum": 1,
+            "options": ['옵션 1', '옵션 2', '옵션 3']
+        },
+        {
+            "type": "file",
+            "is_essential": True,
+            "question": "포트폴리오 파일을 첨부해주세요."
+        }
+    ]
+}

--- a/apply/urls.py
+++ b/apply/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
-from .views import *
+from .views import PostCreate
 
 urlpatterns = [
-    
+    path('', PostCreate.as_view(), name='post-create'),
 ]

--- a/apply/urls.py
+++ b/apply/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, include
-from .views import PostCreate
+from .views import PostCreate, application_create
 
 urlpatterns = [
     path('', PostCreate.as_view(), name='post-create'),
+    path('<int:post_id>/application/', application_create, name='application-create')
 ]

--- a/apply/views.py
+++ b/apply/views.py
@@ -1,8 +1,82 @@
-from rest_framework import generics
-from .serializers import PostSerializer
+from rest_framework import generics, status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from .serializers import PostSerializer, SectionSerializer, LongSentenceSerializer, CheckBoxSerializer, FileSerializer, CheckBoxOptionSerializer
 from .permissions import IsAdministrator
+
+from table.models import Post
+
 
 # 모집 공고를 생성하는 api
 class PostCreate(generics.CreateAPIView):
     serializer_class = PostSerializer
     permission_classes = [IsAdministrator]
+
+
+# section 별로 지원서 문항을 생성하는 api
+"""
+request body
+- section_name
+- section_description
+- question
+    - type
+    - is_essential
+    - question
+    ...
+"""
+@api_view(['POST'])
+def application_create(request, post_id):
+
+    try:
+        post = Post.objects.get(id=post_id)
+    except Post.DoesNotExist:
+        return Response({"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    # section 저장
+    section_serailizer = SectionSerializer(
+        data={
+            "section_name": request.data["section_name"],
+            "post": post_id,
+            "description": request.data["description"]
+        }
+    )
+
+    if section_serailizer.is_valid(raise_exception=True):
+        saved_section = section_serailizer.save()
+
+
+    # 문항 저장
+    for question_dict in request.data["question"]:
+        question_dict["section"] = saved_section.id
+
+        # 장문형 문항 저장
+        if question_dict["type"] == "long_sentence":
+            serializer = LongSentenceSerializer(data=question_dict)
+
+            if serializer.is_valid(raise_exception=True):
+                saved = serializer.save()
+
+        # 객관식 문항 저장
+        elif question_dict["type"] == "checkbox":
+            option_list = question_dict["options"]
+            serializer = CheckBoxSerializer(data=question_dict)
+
+            if serializer.is_valid(raise_exception=True):
+                saved = serializer.save()
+
+            # 객관식 문항의 선택지 저장하기
+            for option in option_list:
+                option_serializer = CheckBoxOptionSerializer(
+                    data={"option": option, "check_box": saved.id})
+                if option_serializer.is_valid(raise_exception=True):
+                    option_serializer.save()
+
+        # 파일 문항 저장
+        elif question_dict["type"] == "file":
+            serializer = FileSerializer(data=question_dict)
+
+            if serializer.is_valid(raise_exception=True):
+                saved = serializer.save()
+
+    return Response({"success": "Application is created"}, status=status.HTTP_201_CREATED)

--- a/apply/views.py
+++ b/apply/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import generics
+from .serializers import PostSerializer
+from .permissions import IsAdministrator
 
-# Create your views here.
+# 모집 공고를 생성하는 api
+class PostCreate(generics.CreateAPIView):
+    serializer_class = PostSerializer
+    permission_classes = [IsAdministrator]

--- a/apply/views.py
+++ b/apply/views.py
@@ -79,4 +79,4 @@ def application_create(request, post_id):
             if serializer.is_valid(raise_exception=True):
                 saved = serializer.save()
 
-    return Response({"success": "Application is created"}, status=status.HTTP_201_CREATED)
+    return Response({"message": "Application is created"}, status=status.HTTP_201_CREATED)

--- a/post/serializers.py
+++ b/post/serializers.py
@@ -10,13 +10,19 @@ class PostContent_PostImageSerializer(serializers.ModelSerializer):
 
 class PostContent_PostSerializer(serializers.ModelSerializer):
     image = PostContent_PostImageSerializer(many=True, read_only = True)     # Post 모델의 related_name과 동일하게 설정
-
+    total_likes = serializers.SerializerMethodField()
+    total_applies = serializers.SerializerMethodField()
     class Meta:
         model = Post
         fields = ['id', 'apply_start_date', 'apply_end_date', 'document_result_date', 'has_interview', 'interview_start_date', 
                 'interview_end_date', 'final_result_date', 'requirement_target', 'title', 'content', 'membership_fee', 'created_at', 
-                'progress', 'image' ]
+                'progress', 'image', 'total_likes', 'total_applies']
 
+    def get_total_likes(self, obj):
+        return obj.total_like_count()
+    
+    def get_total_applies(self, obj):
+        return obj.total_apply_count()
         
 
 

--- a/post/serializers.py
+++ b/post/serializers.py
@@ -14,8 +14,8 @@ class PostContent_PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = ['id', 'apply_start_date', 'apply_end_date', 'document_result_date', 'has_interview', 'interview_start_date', 
-                'interview_end_date', 'final_result_date', 'requirement_target', 'title', 'content', 'membership_fee', 'created_at',
-                'image' ]
+                'interview_end_date', 'final_result_date', 'requirement_target', 'title', 'content', 'membership_fee', 'created_at', 
+                'progress', 'image' ]
 
         
 

--- a/post/views.py
+++ b/post/views.py
@@ -154,17 +154,3 @@ def click_apply_button(request):
         context["button_status"] = "2차 결과 확인"  
     
     return Response(context, status=status.HTTP_200_OK)
-
-
-
-
-    
-
-    
-
-
-
-
-
-
-

--- a/table/models.py
+++ b/table/models.py
@@ -112,8 +112,8 @@ class Post(models.Model):
     crew = models.ForeignKey(Crew, related_name="post", on_delete=models.CASCADE) # Crew의 FK
     created_at = models.DateTimeField(auto_now_add=True) # 모집 공고 생성일
     progress = models.CharField(max_length=300)
-    pass_message = models.CharField(max_length=500)
-    fail_message = models.CharField(max_length=500)
+    pass_message = models.CharField(max_length=500, null=True, blank=True)
+    fail_message = models.CharField(max_length=500, null=True, blank=True)
 
     # def total_apply_count(self):  # 해당 Post에 연결된 apply들이 몇 개인지 계산해서 반환해주는 메서드
     #     return self.apply.count() # related_name 'apply'를 사용함. 따라서 역참조 할 때 apply 이용!

--- a/table/models.py
+++ b/table/models.py
@@ -115,8 +115,11 @@ class Post(models.Model):
     pass_message = models.CharField(max_length=500, null=True, blank=True)
     fail_message = models.CharField(max_length=500, null=True, blank=True)
 
-    # def total_apply_count(self):  # 해당 Post에 연결된 apply들이 몇 개인지 계산해서 반환해주는 메서드
-    #     return self.apply.count() # related_name 'apply'를 사용함. 따라서 역참조 할 때 apply 이용!
+    def total_apply_count(self):  # 해당 Post에 연결된 apply들이 몇 개인지 계산해서 반환해주는 메서드
+        return self.apply.count() # related_name 'apply'를 사용함. 따라서 역참조 할 때 apply 이용!
+
+    def total_like_count(self):   # 해당 Post에 연결된 Like들이 몇 개인지 계산해서 반환해주는 메서드
+        return self.like.count()  # related_name 'like'를 사용함. 따라서 역참조 할 때 like 이용!
 
     def __str__(self):
         return self.title

--- a/table/models.py
+++ b/table/models.py
@@ -102,9 +102,9 @@ class Post(models.Model):
     apply_end_date = models.DateTimeField()       # 서류 마감 날짜
     document_result_date = models.DateTimeField() # 서류 발표 날짜
     has_interview = models.BooleanField(default=True)  # 면접 여부, 기본값 True
-    interview_start_date = models.DateTimeField()   # 면접 시작 날짜
-    interview_end_date = models.DateTimeField()     # 면접 종료 날짜
-    final_result_date = models.DateTimeField()      # 최종 발표 날짜
+    interview_start_date = models.DateTimeField(null=True, blank=True)   # 면접 시작 날짜
+    interview_end_date = models.DateTimeField(null=True, blank=True)     # 면접 종료 날짜
+    final_result_date = models.DateTimeField(null=True, blank=True)      # 최종 발표 날짜
     requirement_target = models.TextField()   # 모집 대상 명시 텍스트
     title = models.CharField(max_length=200)   # 공고 제목
     content = models.TextField()               # 공고 내용

--- a/table/serializers.py
+++ b/table/serializers.py
@@ -48,9 +48,20 @@ class AdministratorSerializer(serializers.ModelSerializer):
         fields = '__all__'   
 
 class PostSerializer(serializers.ModelSerializer):
+    total_likes = serializers.SerializerMethodField()    # 시리얼라이저 메서드 필드 사용
+    total_applies = serializers.SerializerMethodField()  # 시리얼라이저 메서드 필드 사용
     class Meta:
         model = Post
-        fields = '__all__'   
+        fields = ['id', 'apply_start_date', 'apply_end_date', 'document_result_date', 'has_interview', 'interview_start_date', 
+                'interview_end_date', 'final_result_date', 'requirement_target', 'title', 'content', 'membership_fee', 'created_at', 
+                'progress', 'image', 'total_likes', 'total_applies']
+        
+    def get_total_likes(self, obj):     # 시리얼라이저 메서드 필드에 저장될 value를 가져오기 위한 메서드 get_필드이름
+        return obj.total_like_count()   # 여기서 obj는 현재 직렬화를 하려고 하는 Post의 그 객체를 의미
+                                        # 여기서 return 하면 시리얼라이저 안에 있는 메서드 필드에 값이 저장!
+    
+    def get_total_applies(self, obj):  
+        return obj.total_apply_count()
 
 class PostImageSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
## Check 🌈

- [x] merge할 브랜치가 dev인가요? (main ❌)
- [ ] 리뷰가 필요한 경우 review 라벨을 달고 리뷰어를 지정해주세요
- [x] 승인된 PR의 merge는 PR 작성자가 합니다
- [x] PR의 라벨을 제대로 달았나요?

## Description 📒

>모집 공고를 생성하는 api와 지원서 양식(섹션과 문항들)을 생성하는 api를 구현하였습니다. 지원서 양식의 경우, 해당 파트 프론트 개발자와 협의하여 섹션(Section)별로 해당하는 문항들을 Request Body에 담기로 하였습니다. 테스트 코드에서 디테일한 JSON 형식 예시를 볼 수 있습니다.

## Issue Number 💬

#9 

## To Reviewer 💌

1. 지원서 양식을 생성하는 API
프론트까지 생각하며 API를 만들다 보니 한 API 안에서 많은 모델과 시리얼라이저를 사용하고 있습니다. validation은 views.py의 핵심 로직에서 다루는 것보다 분리하는 게 나은 거 같아서 시리얼라이저를 사용했습니다.

2. 추가적인 논의 사항
링크된 이슈의 코멘트를 확인해주세요.

3. 테스트 코드에서 강제 authenticate 관련 의문점
[74c060a](https://github.com/Crews-Server/crews-server/pull/15/commits/74c060a47b1e498dd7b8df48c53e5c7275e28cd8) 
이 커밋 내용에 적은 의문점입니다.